### PR TITLE
[squid:S1197] Array designators "[]" should be on the type, not the variable

### DIFF
--- a/gumga-domain/src/main/java/gumga/framework/domain/domains/youtube/GumgaWebsiteYoutubeURL.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/domains/youtube/GumgaWebsiteYoutubeURL.java
@@ -30,7 +30,7 @@ public class GumgaWebsiteYoutubeURL implements GumgaYoutubeURL {
         try {
             String[] queryParts = url.getQuery().split("&");
             for (String param : queryParts) {
-                String pair[] = param.split("=");
+                String[] pair = param.split("=");
                 String key = URLDecoder.decode(pair[0], "UTF-8");
                 if (key.equals("v")) {
                     return Optional.of(URLDecoder.decode(pair[1], "UTF-8"));

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/api/CSVGeneratorAPI.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/api/CSVGeneratorAPI.java
@@ -75,7 +75,7 @@ public interface CSVGeneratorAPI {
         InputStreamReader isr = new InputStreamReader(csv.getInputStream());
         BufferedReader bf = new BufferedReader(isr);
         String linha;
-        String atributos[] = bf.readLine().split(CSV_SEPARATOR);
+        String[] atributos = bf.readLine().split(CSV_SEPARATOR);
         numeroLinha++;
         Field idField = getIdField(clazz);
         Map<String, String> atributoValor = new HashMap<>();
@@ -95,7 +95,7 @@ public interface CSVGeneratorAPI {
                 continue;
             }
             try {
-                String valores[] = linha.split(CSV_SEPARATOR);
+                String[] valores = linha.split(CSV_SEPARATOR);
                 for (int i = 0; i < valores.length; i++) {
                     atributoValor.put(atributos[i], valores[i]);
                 }
@@ -158,7 +158,7 @@ public interface CSVGeneratorAPI {
         InputStreamReader isr = new InputStreamReader(csv.getInputStream());
         BufferedReader bf = new BufferedReader(isr);
         String linha;
-        String atributos[] = bf.readLine().split(CSV_SEPARATOR);
+        String[] atributos = bf.readLine().split(CSV_SEPARATOR);
         numeroLinha++;
         Field idField = getIdField(clazz);
         Map<String, String> atributoValor = new HashMap<>();
@@ -178,7 +178,7 @@ public interface CSVGeneratorAPI {
                 continue;
             }
             try {
-                String valores[] = linha.split(CSV_SEPARATOR);
+                String[] valores = linha.split(CSV_SEPARATOR);
                 for (int i = 0; i < valores.length; i++) {
                     atributoValor.put(atributos[i], valores[i]);
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - “Array designators "[]" should be on the type, not the variable”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.
Ayman Abdelghany.
