### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/gumga-application/src/main/java/gumga/framework/application/GumgaGenericRepositoryHelper.java
+++ b/gumga-application/src/main/java/gumga/framework/application/GumgaGenericRepositoryHelper.java
@@ -20,6 +20,9 @@ public class GumgaGenericRepositoryHelper {
 
     private static Map<GumgaHqlEntry, GumgaHqlElement> hqlConverter;
 
+    private GumgaGenericRepositoryHelper() {
+    }
+
     public static Map<GumgaHqlEntry, GumgaHqlElement> getHqlConverter() {
         if (hqlConverter == null) {
             hqlConverter = new HashMap<>();

--- a/gumga-core/src/main/java/gumga/framework/core/SearchUtils.java
+++ b/gumga-core/src/main/java/gumga/framework/core/SearchUtils.java
@@ -16,6 +16,9 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class SearchUtils {
 
+    private SearchUtils() {
+    }
+
     /**
      * Aplica um filtro nos valores de um Enum e retorna em um SearchResult
      *

--- a/gumga-core/src/main/java/gumga/framework/core/utils/ReflectionUtils.java
+++ b/gumga-core/src/main/java/gumga/framework/core/utils/ReflectionUtils.java
@@ -13,6 +13,9 @@ import java.util.logging.Logger;
  */
 public class ReflectionUtils {
 
+    private ReflectionUtils() {
+    }
+
     /**
      * Procura um atributo pelo nome em uma classe ou em suas superclasses
      * recursivamente na ordem inversa da hierarquia. Inicialmente na classe,

--- a/gumga-core/src/test/java/gumga/framework/core/ExemploUtils.java
+++ b/gumga-core/src/test/java/gumga/framework/core/ExemploUtils.java
@@ -5,7 +5,10 @@
 package gumga.framework.core;
 
 public class ExemploUtils {
-	
+
+	private ExemploUtils() {
+	}
+
 	public static boolean ehPar(int n){
 		return n % 2 ==0;
 	}

--- a/gumga-domain/src/main/java/gumga/framework/domain/GumgaQueryParserProvider.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/GumgaQueryParserProvider.java
@@ -43,6 +43,9 @@ public class GumgaQueryParserProvider {
 
     public static Map<Class<?>, CriterionParser> defaultMap = null;
 
+    private GumgaQueryParserProvider() {
+    }
+
     public static final Map<Class<?>, CriterionParser> getH2LikeMap() {
         return getBaseMap();
     }

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/io/MenuReader.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/io/MenuReader.java
@@ -23,6 +23,9 @@ public class MenuReader {
 	private static Logger logger = Logger.getLogger(MenuReader.class
 			.getCanonicalName());
 
+	private MenuReader() {
+	}
+
 	public static Menu loadMenu() throws IOException {
 		return digesterMenu(loadMenuFile());
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
