### PR TITLE
[squid:S1609] @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces

### DIFF
--- a/gumga-core/src/main/java/gumga/framework/core/GumgaIdable.java
+++ b/gumga-core/src/main/java/gumga/framework/core/GumgaIdable.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
  *
  * @author Equipe Gumga
  */
+@FunctionalInterface
 public interface GumgaIdable<T extends Serializable> {
 
     T getId();

--- a/gumga-core/src/main/java/gumga/framework/core/Relogio.java
+++ b/gumga-core/src/main/java/gumga/framework/core/Relogio.java
@@ -7,6 +7,7 @@ import java.util.Date;
  *
  * @author Equipe Gumga
  */
+@FunctionalInterface
 public interface Relogio {
 
     Date now();

--- a/gumga-domain/src/main/java/gumga/framework/domain/CriterionParser.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/CriterionParser.java
@@ -7,6 +7,7 @@ import org.hibernate.criterion.Criterion;
  *
  * @author munif
  */
+@FunctionalInterface
 public interface CriterionParser {
 
     Criterion parse(String field, String value);

--- a/gumga-domain/src/main/java/gumga/framework/domain/repository/ISpecification.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/repository/ISpecification.java
@@ -5,6 +5,7 @@ import com.mysema.query.jpa.JPQLQuery;
 /**
  * Interface para consultas mais complexas
  */
+@FunctionalInterface
 public interface ISpecification {
 
     JPQLQuery createQuery(JPQLQuery query);

--- a/gumga-domain/src/main/java/gumga/framework/domain/seed/AppSeed.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/seed/AppSeed.java
@@ -7,6 +7,7 @@ import java.io.IOException;
  *
  * @author munif
  */
+@FunctionalInterface
 public interface AppSeed {
 
     void loadSeed() throws IOException;

--- a/gumga-domain/src/main/java/gumga/framework/domain/service/GumgaDeletableServiceable.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/service/GumgaDeletableServiceable.java
@@ -3,6 +3,7 @@ package gumga.framework.domain.service;
 /**
  * Service com a operação de delete
  */
+@FunctionalInterface
 public interface GumgaDeletableServiceable<T> {
 
     public void delete(T resource);

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/menu/GumgaMenuService.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/menu/GumgaMenuService.java
@@ -1,5 +1,6 @@
 package gumga.framework.presentation.menu;
 
+@FunctionalInterface
 public interface GumgaMenuService {
 
 	Menu getMenu();

--- a/gumga-security/src/main/java/gumga/framework/security/ApiOperationTranslator.java
+++ b/gumga-security/src/main/java/gumga/framework/security/ApiOperationTranslator.java
@@ -9,6 +9,7 @@ package gumga.framework.security;
  *
  * @author munif
  */
+@FunctionalInterface
 public interface ApiOperationTranslator {
 
     String getOperation(String url, String method);

--- a/gumga-validation/src/main/java/gumga/framework/validation/GumgaFieldValidator.java
+++ b/gumga-validation/src/main/java/gumga/framework/validation/GumgaFieldValidator.java
@@ -12,6 +12,7 @@ import com.google.common.base.Optional;
  * 
  * @param <T>
  */
+@FunctionalInterface
 public interface GumgaFieldValidator<T> {
 
 	public Optional<GumgaValidationError> validate(T value, Errors errors);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1609 - “ @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1609

Please let me know if you have any questions.
Ayman Abdelghany.
