### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/gumga-application/src/main/java/gumga/framework/application/GumgaGenericRepository.java
+++ b/gumga-application/src/main/java/gumga/framework/application/GumgaGenericRepository.java
@@ -64,7 +64,7 @@ public class GumgaGenericRepository<T, ID extends Serializable> extends SimpleJp
         Long count = count(query);
         List<T> data = query.isCountOnly() ? Collections.EMPTY_LIST : getOrdered(query);
 
-        return new SearchResult<T>(query, count, data);
+        return new SearchResult<>(query, count, data);
     }
 
     private List<T> getOrdered(QueryObject query) {
@@ -229,7 +229,7 @@ public class GumgaGenericRepository<T, ID extends Serializable> extends SimpleJp
         qConsulta.setMaxResults(query.getPageSize());
         qConsulta.setFirstResult(query.getStart());
         List resultList = query.isCountOnly() ? Collections.emptyList() : qConsulta.getResultList();
-        return new SearchResult<T>(query, total, resultList);
+        return new SearchResult<>(query, total, resultList);
     }
 
     @Override
@@ -253,7 +253,7 @@ public class GumgaGenericRepository<T, ID extends Serializable> extends SimpleJp
         qConsulta.setFirstResult(whereQuery.getStart());
         List resultList = qConsulta.getResultList();
 
-        return new SearchResult<A>(whereQuery, total, resultList);
+        return new SearchResult<>(whereQuery, total, resultList);
     }
 
     public SearchResult<T> search(String hql, Map<String, Object> params) {
@@ -265,7 +265,7 @@ public class GumgaGenericRepository<T, ID extends Serializable> extends SimpleJp
         }
         List<T> result = query.getResultList();
         int total = result.size();
-        return new SearchResult<T>(0, total, total, result);
+        return new SearchResult<>(0, total, total, result);
     }
 
     @Override

--- a/gumga-application/src/main/java/gumga/framework/application/GumgaUntypedRepository.java
+++ b/gumga-application/src/main/java/gumga/framework/application/GumgaUntypedRepository.java
@@ -75,7 +75,7 @@ public class GumgaUntypedRepository {
     }
 
     public static List<Field> getTodosAtributos(Class classe) throws SecurityException {
-        List<Field> aRetornar = new ArrayList<Field>();
+        List<Field> aRetornar = new ArrayList<>();
         if (!classe.getSuperclass().equals(Object.class)) {
             aRetornar.addAll(getTodosAtributos(classe.getSuperclass()));
         }

--- a/gumga-core/src/main/java/gumga/framework/core/GumgaValues.java
+++ b/gumga-core/src/main/java/gumga/framework/core/GumgaValues.java
@@ -64,7 +64,7 @@ public interface GumgaValues {
      * @return
      */
     default Set<String> getUrlsToNotLog() {
-        return new HashSet<String>();
+        return new HashSet<>();
     }
 
     /**

--- a/gumga-core/src/main/java/gumga/framework/core/SearchUtils.java
+++ b/gumga-core/src/main/java/gumga/framework/core/SearchUtils.java
@@ -26,7 +26,7 @@ public class SearchUtils {
      * @return Resultado da aplicação do filtro
      */
     public static <E extends Enum<E>> SearchResult<E> filterEnum(Class<E> enumClass, QueryObject query) {
-        List<E> filtered = new ArrayList<E>();
+        List<E> filtered = new ArrayList<>();
 
         for (E value : enumClass.getEnumConstants()) {
             if (StringUtils.startsWithIgnoreCase(value.name(), query.getQ())) {
@@ -36,7 +36,7 @@ public class SearchUtils {
 
         sortEnum(query.getSortDir(), filtered);
         List<E> paginated = paginate(query.getStart(), query.getPageSize(), filtered);
-        return new SearchResult<E>(query, filtered.size(), paginated);
+        return new SearchResult<>(query, filtered.size(), paginated);
     }
 
     private static <T> List<T> paginate(int start, int pageSize, List<T> filtered) {
@@ -47,9 +47,9 @@ public class SearchUtils {
 
     private static <E extends Enum<E>> void sortEnum(String direction, List<E> filtered) {
         if ("asc".equalsIgnoreCase(direction)) {
-            sort(filtered, new EnumNameComparator<E>());
+            sort(filtered, new EnumNameComparator<>());
         } else if ("desc".equalsIgnoreCase(direction)) {
-            sort(filtered, new EnumNameComparator<E>());
+            sort(filtered, new EnumNameComparator<>());
             reverse(filtered);
         }
     }

--- a/gumga-domain/src/main/java/gumga/framework/domain/Pesquisa.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/Pesquisa.java
@@ -223,7 +223,7 @@ public class Pesquisa<T> implements Criteria {
 
     @Override
     public List<T> list() throws HibernateException {
-        List<T> newList = new LinkedList<T>();
+        List<T> newList = new LinkedList<>();
         for (Object obj : criteria.list()) {
             newList.add(clazz.cast(obj));
         }

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/AbstractGumgaAPI.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/AbstractGumgaAPI.java
@@ -33,7 +33,7 @@ public abstract class AbstractGumgaAPI<T> extends AbstractNoDeleteGumgaAPI<T> {
     public RestResponse<T> delete(@PathVariable Long id) {
         T entity = service.view(id);
         service.delete(entity);
-        return new RestResponse<T>(getEntityDeletedMessage(entity));
+        return new RestResponse<>(getEntityDeletedMessage(entity));
     }
 
     public void setService(GumgaServiceable<T> service) {

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/GlobalExceptionHandler.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/GlobalExceptionHandler.java
@@ -191,7 +191,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         if (HttpStatus.INTERNAL_SERVER_ERROR.equals(status)) {
             request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST);
         }
-        return new ResponseEntity<Object>(new ErrorResource("BAD Request", ex.getClass().getSimpleName(), ex.getMessage()), headers, status);
+        return new ResponseEntity<>(new ErrorResource("BAD Request", ex.getClass().getSimpleName(), ex.getMessage()), headers, status);
     }
 
 }

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/GumgaGateway.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/GumgaGateway.java
@@ -26,7 +26,7 @@ public abstract class GumgaGateway<A extends GumgaIdable<ID>, ID extends Seriali
     @Override
     public SearchResult<DTO> pesquisa(QueryObject query) {
         SearchResult<A> pesquisa = delegate.pesquisa(query);
-        return new SearchResult<DTO>(query, pesquisa.getCount(), translator.from((List<A>) pesquisa.getValues()));
+        return new SearchResult<>(query, pesquisa.getCount(), translator.from((List<A>) pesquisa.getValues()));
     }
 
     @Override

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/api/AbstractNoDeleteGumgaAPI.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/api/AbstractNoDeleteGumgaAPI.java
@@ -35,7 +35,7 @@ public abstract class AbstractNoDeleteGumgaAPI<T> extends
     public RestResponse<T> save(@RequestBody @Valid T model, BindingResult result) {
         beforeSave(model);
         T entity = saveOrCry(model, result);
-        return new RestResponse<T>(entity, getEntitySavedMessage(entity));
+        return new RestResponse<>(entity, getEntitySavedMessage(entity));
     }
 
     @GumgaSwagger
@@ -46,7 +46,7 @@ public abstract class AbstractNoDeleteGumgaAPI<T> extends
             @Valid @RequestBody T model, BindingResult result) {
         beforeUpdate(id, model);
         T entity = saveOrCry(model, result);
-        return new RestResponse<T>(entity, getEntityUpdateMessage(entity));
+        return new RestResponse<>(entity, getEntityUpdateMessage(entity));
     }
 
     private T saveOrCry(T model, BindingResult result) {

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/api/CSVGeneratorAPI.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/api/CSVGeneratorAPI.java
@@ -147,7 +147,7 @@ public interface CSVGeneratorAPI {
                 ex.printStackTrace();
             }
         }
-        return new SearchResult<String>(0, problemas.size(), problemas.size(), problemas);
+        return new SearchResult<>(0, problemas.size(), problemas.size(), problemas);
     }
 
     @ApiOperation(value = "csvuploadvalidate", notes = "Faz validação da importação via csv.")
@@ -229,7 +229,7 @@ public interface CSVGeneratorAPI {
                 ex.printStackTrace();
             }
         }
-        return new SearchResult<String>(0, problemas.size(), problemas.size(), problemas);
+        return new SearchResult<>(0, problemas.size(), problemas.size(), problemas);
     }
 
     public static String classToCsvTitle(Class clazz) {

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/gateway/GumgaNoDeleteGateway.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/gateway/GumgaNoDeleteGateway.java
@@ -24,7 +24,7 @@ public abstract class GumgaNoDeleteGateway<A extends GumgaIdable<?>, DTO> implem
 	@Override
 	public SearchResult<DTO> pesquisa(QueryObject query) {
 		SearchResult<A> pesquisa = delegate.pesquisa(query);
-		return new SearchResult<DTO>(query, pesquisa.getCount(), translator.from((List<A>) pesquisa.getValues()));
+		return new SearchResult<>(query, pesquisa.getCount(), translator.from((List<A>) pesquisa.getValues()));
 	}
 
 	@Override

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/gateway/GumgaReadOnlyGateway.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/gateway/GumgaReadOnlyGateway.java
@@ -23,7 +23,7 @@ public abstract class GumgaReadOnlyGateway<A extends GumgaIdable<?>, DTO> implem
 	@Override
 	public SearchResult<DTO> pesquisa(QueryObject query) {
 		SearchResult<A> pesquisa = delegate.pesquisa(query);
-		return new SearchResult<DTO>(query, pesquisa.getCount(), translator.from((List<A>) pesquisa.getValues()));
+		return new SearchResult<>(query, pesquisa.getCount(), translator.from((List<A>) pesquisa.getValues()));
 	}
 
 	@Override

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/io/MenuReader.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/io/MenuReader.java
@@ -79,7 +79,7 @@ public class MenuReader {
 		Pattern pattern = Pattern.compile("\\{(.*?)\\}");
 		Matcher matchPattern = pattern.matcher(menuOption);
 
-		Map<String, String> properties = new HashMap<String, String>();
+		Map<String, String> properties = new HashMap<>();
 
 		while (matchPattern.find()) {
 			String propertiesInline = matchPattern.group(1).trim();

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/menu/Menu.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/menu/Menu.java
@@ -43,7 +43,7 @@ public class Menu {
 	}
 	
 	public List<MenuComponent> flat() {
-		List<MenuComponent> flatted = new LinkedList<MenuComponent>();
+		List<MenuComponent> flatted = new LinkedList<>();
 		
 		for (MenuComponent item : menu) 
 			flatted.addAll(item.flat());

--- a/gumga-presentation/src/main/java/gumga/framework/presentation/menu/MenuGrupo.java
+++ b/gumga-presentation/src/main/java/gumga/framework/presentation/menu/MenuGrupo.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class MenuGrupo extends MenuComponent {
 
-	private final List<MenuComponent> itens = new LinkedList<MenuComponent>();
+	private final List<MenuComponent> itens = new LinkedList<>();
 	
 	public MenuGrupo(String label) {
 		super(label);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
