### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the corre

### DIFF
--- a/gumga-core/src/main/java/gumga/framework/core/GumgaThreadScope.java
+++ b/gumga-core/src/main/java/gumga/framework/core/GumgaThreadScope.java
@@ -20,41 +20,41 @@ public class GumgaThreadScope {
     /**
      * Ip da requisição
      */
-    public final static ThreadLocal<String> ip = new ThreadLocal<>();
+    public static final ThreadLocal<String> ip = new ThreadLocal<>();
     /**
      * login do usuário da requisição
      */
-    public final static ThreadLocal<String> login = new ThreadLocal<>();
+    public static final ThreadLocal<String> login = new ThreadLocal<>();
     /**
      * nome organização do usuário da requisição
      */
-    public final static ThreadLocal<String> organization = new ThreadLocal<>();
+    public static final ThreadLocal<String> organization = new ThreadLocal<>();
     /**
      * código da organização do usuário da requisição
      */
-    public final static ThreadLocal<String> organizationCode = new ThreadLocal<>();
+    public static final ThreadLocal<String> organizationCode = new ThreadLocal<>();
     /**
      * chave da operação da requisição
      */
-    public final static ThreadLocal<String> operationKey = new ThreadLocal<>();
+    public static final ThreadLocal<String> operationKey = new ThreadLocal<>();
     /**
      * irá ignorar a checagem de propriedade dos registros do Tenacy
      */
-    public final static ThreadLocal<Boolean> ignoreCheckOwnership = new ThreadLocal<>();
+    public static final ThreadLocal<Boolean> ignoreCheckOwnership = new ThreadLocal<>();
     /**
      * token da requisição
      */
-    public final static ThreadLocal<String> gumgaToken = new ThreadLocal<>();
+    public static final ThreadLocal<String> gumgaToken = new ThreadLocal<>();
 
     /**
      * id do Software que fez a requisição
      */
-    public final static ThreadLocal<String> softwareName = new ThreadLocal<>();
+    public static final ThreadLocal<String> softwareName = new ThreadLocal<>();
 
     /**
      * @return o parâmetro a ser utilizado na comparação do Tenancy
      */
-    public final static String getOiWildCard() {
+    public static final String getOiWildCard() {
         if (organizationCode.get() == null) {
             return "%";
         }

--- a/gumga-core/src/main/java/gumga/framework/core/JavaScriptEngine.java
+++ b/gumga-core/src/main/java/gumga/framework/core/JavaScriptEngine.java
@@ -15,7 +15,7 @@ import javax.script.ScriptException;
  */
 public class JavaScriptEngine {
 
-    private final static ScriptEngineManager engineManager = new ScriptEngineManager();
+    private static final ScriptEngineManager engineManager = new ScriptEngineManager();
 
     /**
      * Avalia o valor do script com o contexto de objetos java passados no map e

--- a/gumga-domain/src/main/java/gumga/framework/domain/support/EntityValidatorSupport.java
+++ b/gumga-domain/src/main/java/gumga/framework/domain/support/EntityValidatorSupport.java
@@ -16,8 +16,8 @@ import org.slf4j.LoggerFactory;
  */
 public class EntityValidatorSupport {
 
-    private final static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-    private final static Logger logger = LoggerFactory.getLogger(EntityValidatorSupport.class);
+    private static final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private static final Logger logger = LoggerFactory.getLogger(EntityValidatorSupport.class);
 
     public static void assertEntidadeConsistente(GumgaModel<Long> resource) {
         Set<ConstraintViolation<GumgaModel<Long>>> violations = validator.validate(resource);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
